### PR TITLE
Github Actions build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
     - run: yarn install
     - run: yarn semantic-release
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,11 +7,7 @@
         "name": "Timofey (xzeldon)",
         "email": "contact@zeldon.ru"
     },
-    "repository": {
-        "type": "git",
-        "url": "git+git@github.com/xzeldon/vk-di.git",
-        "directory": "packages/core"
-    },
+    "repository": "https://github.com/xzeldon/vk-di",
     "keywords": [
         "vk",
         "api",

--- a/packages/simple-bot/package.json
+++ b/packages/simple-bot/package.json
@@ -7,11 +7,7 @@
         "name": "Timofey (xzeldon)",
         "email": "contact@zeldon.ru"
     },
-    "repository": {
-        "type": "git",
-        "url": "git+git@github.com/xzeldon/vk-di.git",
-        "directory": "packages/bot"
-    },
+    "repository": "https://github.com/xzeldon/vk-di",
     "keywords": [
         "vk",
         "api",


### PR DESCRIPTION
Semantic release is usung ``repository.url`` from ``package.json``. Due to the fact that it was declared as ssh, the build failed.